### PR TITLE
fix: checkout master again, after changelog update

### DIFF
--- a/.github/workflows/publish_release_draft.yml
+++ b/.github/workflows/publish_release_draft.yml
@@ -131,6 +131,10 @@ jobs:
           MERGE_DELETE_BRANCH: true
       # END CHANGELOG PORTION
 
+      - name: Post Changelog Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       # Merge support changes into develop so they can be included in the next release
       - name: Merge master/support -> develop


### PR DESCRIPTION
### Summary
> High level summary of what was done

### Testing Steps
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] Step 4

### Issues/Concerns
- A concern or issue
- A second concern or issue

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
